### PR TITLE
Fixed an error for failed tests with numeric values.

### DIFF
--- a/Jasmine2-teamcityreporter.js
+++ b/Jasmine2-teamcityreporter.js
@@ -78,11 +78,11 @@ getJasmineRequireObj().TeamcityReporter = function () {
         }
 
         function escapeTeamcityString(message) {
-            if (!message) {
+            if ((message === null) || (message === undefined)) {
                 return "";
             }
 
-            return message.replace(/\|/g, "||")
+            return message.toString().replace(/\|/g, "||")
                           .replace(/\'/g, "|'")
                           .replace(/\n/g, "|n")
                           .replace(/\r/g, "|r")


### PR DESCRIPTION
We needed to ensure that message was a string for the .replace() call to avoid an undefined is not a function exception.  While we were there we made some changes to the falsy logic as well.  
